### PR TITLE
add dynamic grain data for elb

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Version 0.4.0
+
+* Adds elb grains to be used in zero downtime deployment
+
 ## Version 0.3.0
 
 * Migrate back to using grain data

--- a/README.rst
+++ b/README.rst
@@ -6,7 +6,7 @@ AWS Saltstack formula
 Features
 --------
 
-* Creates grain details to summarise useful information on the current instance and vpc.
+* Creates grain details to summarise useful information on the current instance, vpc and elb.
 
 
 .. code-block::
@@ -19,3 +19,14 @@ Features
         <ip-address>: 
             private_dns_name: <private_dns_name>
             private_dns_name_safe: <private_dns_name_safe>
+
+  lbs:                      # A dictionary of {lb_name1:{attrs..}, {lb_name2:{attrs..}}
+    <load-balancer-name>:   # A load balancer name that shares the same vpc_id as this instance
+                            # and has this instance's instance_id in its "instances" list.
+      dns_name:             # The dns name of the load balancer as taken from elb            
+      name:                 # The load balancer resource name (short). This is the same
+                            # as the <load-balancer-name> key name.
+      scheme:               # The type of load balancer eg. internet-facing
+      security_groups:      # A list of the load balancer's security groups 
+      vpc_id:               # The vpc_id (also used to filter this instance's load balancers)
+ 

--- a/_grains/elb_lbs.py
+++ b/_grains/elb_lbs.py
@@ -1,0 +1,71 @@
+#!/usr/bin/env python
+import boto.ec2.elb
+import boto.utils
+import logging
+import salt.log
+
+
+# configure a logger in case we are running it directly from python
+# (eg: command line or testing)
+if not salt.log.is_logging_configured():
+    salt.log.setup_console_logger()
+log = logging.getLogger(__name__)
+
+
+def get_elb_lbs():
+    """
+    Returns a dictionary of load balancer names as keys
+    each with their respective attributes
+    """
+
+    # attributes to extract from the load balancer boto objects
+    # this could possibly be a named argument too
+    extract_attrs = ['scheme', 'dns_name', 'vpc_id', 'name', 'security_groups']
+
+    try:
+        instance_metadata = boto.utils.get_instance_metadata(timeout=5, num_retries=2)
+    except Exception as e:
+        log.exception("Error getting ELB names: {}".format(e))
+        return {'custom_grain_error': True}
+
+    # Setup the lbs grain
+    lbs_grain = {'lbs': {}}
+
+    # Collect details about this instance
+    vpc_id = instance_metadata['network']['interfaces']['macs'].values()[0]['vpc-id']
+    region = instance_metadata['placement']['availability-zone'][:-1]
+
+    # Collect load balancers of this instance (in the same vpc)
+    try:
+        elb_connection = boto.ec2.elb.connect_to_region(region)
+
+        # find load balancers by vpc_id
+        all_lbs = [lb for lb in elb_connection.get_all_load_balancers()
+                   if lb.vpc_id == vpc_id]
+        log.debug('all lbs before filtering by instance id: {}'.format(all_lbs))
+
+        # further filter the load balancers by instance id
+        lbs = [lb for lb in all_lbs for inst in lb.instances
+               if inst.id == instance_metadata['instance-id']]
+        # initialise and populate the output of load balancers
+        out = {}
+        [out.update({l.name: {}}) for l in lbs]
+        [out[l.name].update({attr: getattr(l, attr, None)})
+         for attr in extract_attrs for l in lbs]
+
+        if not out:
+            # This loglevel could perhaps be adjusted to something more visible
+            log.warning("No ELBs found for this instance, this is unusual, "
+                        "but we will not break highstate")
+
+        lbs_grain['lbs'] = out
+
+    except Exception as e:
+        # This prints a user-friendly error with stacktrace
+        log.exception("Error getting ELB names: {}".format(e))
+        return {'custom_grain_error': True}
+
+    return lbs_grain
+
+if __name__ == '__main__':
+    print get_elb_lbs()


### PR DESCRIPTION
# What does it do ?

Gets all load balancer names for the instance and a few of their attributes directly from boto ELB and stores them into a top level grain called "lbs". It will get all the load balancers and first filter by the instance's vpc_id and then by ensuring the instance_id is in the remaining load balancer's "instances" list. 
# Why?

The ELB name is needed because we need to know which ELBs to deregister during
zero downtime upgrade and the naming convention changed with https://github.com/ministryofjustice/bootstrap-cfn/pull/143
which currently breaks zero downtime upgrade. Previously we used to construct this as the name was predictable eg: foo-bar would become ELBfoobar, but currently this gets autonamed. There will be one or more pull requests in the salt repos (eg: moj-docker-deploy) that leverage this request in order to pass the correct name into the elb_reg.instance_deregistered 
# Actual error

The actual error which made us realise we need this was: 

```
[INFO ] Executing state elb_reg.instance_deregistered for ELB-shiny-test-ext
[WARNING ] BotoServerError: 403 Forbidden
<ErrorResponse xmlns="http://elasticloadbalancing.amazonaws.com/doc/2012-06-01/">
<Error>
<Type>Sender</Type>
<Code>AccessDenied</Code>
<Message>User: arn:aws:sts::880656497252:assumed-role/shiny-project-dev-adc14f05-BaseHostRole-L9PN16XRU4XJ/i-6f8047c3 is not authorized to perform: elasticloadbalancing:DeregisterInstancesFromLoadBalancer
...
[Sep-7 10:40] Filippos Chalvatzoglou: on resource: arn:aws:elasticloadbalancing:eu-west-1:880656497252:loadbalancer/ELB-shiny-test-ext</Message>  </Error>  <RequestId>407e8a90-5544-11e5-b851-71222939b06b</RequestId>  </ErrorResponse>
```

And worth noting that although we get a 403 error, if it wasn't for security reasons we would get a 404 error because in reality the error is that `ELB-shiny-test-ext` didn't exist and the real (autogenerated) name was in fact `shiny-pro-ELBshiny-NFGERR664KZ7-1985355`.
