### PR TITLE
Add EIP associaton script

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -51,3 +51,25 @@ ElasticacheReplicationGroupName containing the replication group name.
        {'address': <address>, 'port': <port>}
      ]
    }
+   
+Auto EIP's
+##########
+
+By specifying a list of elastic ips in the pillar data and running the state `aws.autoeips`,
+instances can be setup to automatically poll for available EIP's in the specified list, and,
+if they do not have an EIP attached, associate with an available one. This can prove useful 
+when there is a group of instances that need to be whitelisted in a firewall by IP, providing
+a more resilient and automated solution than assigning EIP's manually.
+
+.. code::
+
+	aws:
+		# A list of eips to attempt to associate with (required) 
+		eips:
+			- 1.2.3.4
+			- 5.6.7.8
+		# File path to autoeip log (optional)
+		auto_eip_log: /var/log/autoeips.log
+    # Level of logging output (optional)
+    log_level': 'INFO'
+			

--- a/aws/autoeips.sls
+++ b/aws/autoeips.sls
@@ -1,0 +1,14 @@
+autoeips.py:
+  file.managed:
+    - name: /usr/local/bin/autoeips.py
+    - source: salt://aws/files/autoeips.py
+    - user: root
+    - group: root
+    - mode: 755
+    - template: jinja
+
+cron_autoeips:
+  cron.present:
+    - name: python /usr/local/bin/autoeips.py >> /var/log/autoeips.log
+    - user: root
+    - minute: "*/1"

--- a/aws/autoeips.sls
+++ b/aws/autoeips.sls
@@ -1,3 +1,4 @@
+{% from "aws/map.jinja" import aws with context %}
 autoeips.py:
   file.managed:
     - name: /usr/local/bin/autoeips.py
@@ -9,6 +10,6 @@ autoeips.py:
 
 cron_autoeips:
   cron.present:
-    - name: python /usr/local/bin/autoeips.py >> /var/log/autoeips.log
+    - name: python /usr/local/bin/autoeips.py >> {{ aws.auto_eip_log }}
     - user: root
     - minute: "*/1"

--- a/aws/files/autoeips.py
+++ b/aws/files/autoeips.py
@@ -1,35 +1,35 @@
 {% from "aws/map.jinja" import aws with context %}
-# !/usr/bin/env python
+#!/usr/bin/env python
+
 import boto.ec2
-from boto.exception import EC2ResponseError
 import boto.utils
 import logging
-import salt.log
- # Set up the logging
+
+
+# Set up the logging
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger("aws:autoeips")
 logging.getLogger("requests").setLevel(logging.WARNING)
-    
-    
-class AutoEIP():
-    filter_addresses = {{ aws.eips }}
+
+
+class AutoEIP(object):
+    filter_addresses = {{aws.eips}}
     ec2_connection = None
     instance_metadata = None
-   
+
     def __init__(self):
         self.instance_metadata = self.get_instance_metadata()
         self.instance_id = self.instance_metadata.get('instance-id')
         # Collect details about this instance
         vpc_id = self.instance_metadata['network']['interfaces']['macs'].values()[0]['vpc-id']
         region = self.instance_metadata['placement']['availability-zone'][:-1]
-    
+
         try:
             self.ec2_connection = boto.ec2.connect_to_region(region)
         except Exception as e:
-          # This prints a user-friendly error with stacktrace
-          print("Error getting EC2 conection: {}".format(e))
-          return None
-            
+            # This prints a user-friendly error with stacktrace
+            print("Error getting EC2 conection: {}".format(e))
+
     def update_association(self, force=False):
         instance_associations = self.get_instance_association()
         if len(instance_associations) < 1 or force:
@@ -37,61 +37,61 @@ class AutoEIP():
             filtered_eips = self.get_unassociated_eips()
             self.associate_eip(filtered_eips)
         else:
-            print("Already associated with EIP: {}".format(instance_associations[0]))
-        
+            print("Already associated with EIP: {}".format(
+                instance_associations[0]))
+
     def get_instance_association(self):
-        instance_id =self.instance_metadata.get('instance-id', None)
-        return self.ec2_connection.get_all_addresses(filters={'instance-id': instance_id})
-    
-    
+        instance_id = self.instance_metadata.get('instance-id', None)
+        return self.ec2_connection.get_all_addresses(
+            filters={'instance-id': instance_id})
+
     def get_instance_metadata(self):
         """
         Prints a mapping of private ip addresses to private dns names
         """
         try:
-            instance_metadata = boto.utils.get_instance_metadata(timeout=5, num_retries=2)
-            return instance_metadata
+            return boto.utils.get_instance_metadata(timeout=5, num_retries=2)
         except Exception as e:
             sys.stderr.write("Error getting VPC ips: {}".format(e))
             return {}
-    
-    
-    def associate_eip(self,
-                      eips,
-                      retries=3):
-        if self.instance_id is None:
-            print('Error getting instance_id')
+
+    def associate_eip(self, eips, retries=3):
+        if not self.instance_id:
+            print "Error getting instance_id"
             return False
         for retry in range(retries):
-            print ("retry: {}".format(retry) )
+            print "retry: {}".format(retry)
             for eip in eips:
-                print ("Associating instance: {} with eip: {}".format(self.instance_id, eip.allocation_id))
-                success = eip.associate(instance_id=self.instance_id,
-                              allow_reassociation=False)
+                print "Associating instance: {} with eip: {}".format(
+                    self.instance_id, eip.allocation_id)
+
+                success = eip.associate(
+                    instance_id=self.instance_id, allow_reassociation=False)
                 if success:
                     return True
-            
+
         return False
+
     def get_unassociated_eips(self):
-      """
-      """
-      try:
-          try:
-            eips = self.ec2_connection.get_all_addresses(addresses=self.filter_addresses)
-            unassociated_eips = [eip for eip in eips if eip.association_id is None]
+        try:
+            eips = self.ec2_connection.get_all_addresses(
+                addresses=self.filter_addresses)
+
+            unassociated_eips = \
+                [eip for eip in eips if eip.association_id is None]
+
             print("Found {} eips: {}".format(len(eips), eips))
-            print("Found {} unassociated eips: {}".format(len(unassociated_eips), unassociated_eips))
+            print("Found {} unassociated eips: {}".format(
+                len(unassociated_eips), unassociated_eips))
+
             return unassociated_eips
-          except EC2ResponseError as e:
+
+        except Exception as e:
             # This prints a user-friendly error with stacktrace
             logger.exception("Error getting EIPS: {}".format(e))
             return None
-      except Exception as e:
-          # This prints a user-friendly error with stacktrace
-          logger.exception("Error getting EIPS: {}".format(e))
-          return None
+
 
 if __name__ == '__main__':
     autoeip = AutoEIP()
     autoeip.update_association()
-    

--- a/aws/files/autoeips.py
+++ b/aws/files/autoeips.py
@@ -1,0 +1,97 @@
+{% from "aws/map.jinja" import aws with context %}
+# !/usr/bin/env python
+import boto.ec2
+from boto.exception import EC2ResponseError
+import boto.utils
+import logging
+import salt.log
+ # Set up the logging
+logging.basicConfig(level=logging.INFO)
+logger = logging.getLogger("aws:autoeips")
+logging.getLogger("requests").setLevel(logging.WARNING)
+    
+    
+class AutoEIP():
+    filter_addresses = {{ aws.eips }}
+    ec2_connection = None
+    instance_metadata = None
+   
+    def __init__(self):
+        self.instance_metadata = self.get_instance_metadata()
+        self.instance_id = self.instance_metadata.get('instance-id')
+        # Collect details about this instance
+        vpc_id = self.instance_metadata['network']['interfaces']['macs'].values()[0]['vpc-id']
+        region = self.instance_metadata['placement']['availability-zone'][:-1]
+    
+        try:
+            self.ec2_connection = boto.ec2.connect_to_region(region)
+        except Exception as e:
+          # This prints a user-friendly error with stacktrace
+          print("Error getting EC2 conection: {}".format(e))
+          return None
+            
+    def update_association(self, force=False):
+        instance_associations = self.get_instance_association()
+        if len(instance_associations) < 1 or force:
+            print("Associating with any available eips")
+            filtered_eips = self.get_unassociated_eips()
+            self.associate_eip(filtered_eips)
+        else:
+            print("Already associated with EIP: {}".format(instance_associations[0]))
+        
+    def get_instance_association(self):
+        instance_id =self.instance_metadata.get('instance-id', None)
+        return self.ec2_connection.get_all_addresses(filters={'instance-id': instance_id})
+    
+    
+    def get_instance_metadata(self):
+        """
+        Prints a mapping of private ip addresses to private dns names
+        """
+        try:
+            instance_metadata = boto.utils.get_instance_metadata(timeout=5, num_retries=2)
+            return instance_metadata
+        except Exception as e:
+            sys.stderr.write("Error getting VPC ips: {}".format(e))
+            return {}
+    
+    
+    def associate_eip(self,
+                      eips,
+                      retries=3):
+        if self.instance_id is None:
+            print('Error getting instance_id')
+            return False
+        for retry in range(retries):
+            print ("retry: {}".format(retry) )
+            for eip in eips:
+                print ("Associating instance: {} with eip: {}".format(self.instance_id, eip.allocation_id))
+                success = eip.associate(instance_id=self.instance_id,
+                              allow_reassociation=False)
+                if success:
+                    return True
+            
+        return False
+    def get_unassociated_eips(self):
+      """
+      """
+      try:
+          try:
+            eips = self.ec2_connection.get_all_addresses(addresses=self.filter_addresses)
+            unassociated_eips = [eip for eip in eips if eip.association_id is None]
+            print("Found {} eips: {}".format(len(eips), eips))
+            print("Found {} unassociated eips: {}".format(len(unassociated_eips), unassociated_eips))
+            return unassociated_eips
+          except EC2ResponseError as e:
+            # This prints a user-friendly error with stacktrace
+            logger.exception("Error getting EIPS: {}".format(e))
+            return None
+      except Exception as e:
+          # This prints a user-friendly error with stacktrace
+          logger.exception("Error getting EIPS: {}".format(e))
+          return None
+
+if __name__ == '__main__':
+    autoeip = AutoEIP()
+    autoeip.update_association()
+    

--- a/aws/files/autoeips.py
+++ b/aws/files/autoeips.py
@@ -17,6 +17,7 @@ class AutoEIP(object):
     filter_addresses = {{aws.eips}}
     ec2_connection = None
     instance_metadata = None
+    instance_id = None
 
     def __init__(self):
         self.instance_metadata = self.get_instance_metadata()
@@ -47,9 +48,8 @@ class AutoEIP(object):
                 instance_associations[0]))
 
     def get_instance_association(self):
-        instance_id = self.instance_metadata.get('instance-id', None)
         return self.ec2_connection.get_all_addresses(
-            filters={'instance-id': instance_id})
+            filters={'instance-id': self.instance_id})
 
     def get_instance_metadata(self):
         """
@@ -61,11 +61,9 @@ class AutoEIP(object):
             logger.critical("Critical error getting instance metadata, "
                             "exiting")
             self.safe_exit(1)
+        return instance_metadata
 
     def associate_eip(self, eips, retries=3):
-        if not self.instance_id:
-            logger.critical("Error getting instance_id")
-            return False
         for retry in range(retries):
             for eip in eips:
                 logger.info("Associating instance: {} with eip: {}..."

--- a/aws/files/autoeips.py
+++ b/aws/files/autoeips.py
@@ -3,6 +3,7 @@
 
 import boto.ec2
 import boto.utils
+from boto.exception import EC2ResponseError
 import logging
 import sys
 

--- a/aws/files/autoeips.py
+++ b/aws/files/autoeips.py
@@ -1,4 +1,3 @@
-from botocore.vendored.requests.packages.urllib3.util.retry import Retry
 {% from "aws/map.jinja" import aws with context %}
 #!/usr/bin/env python
 

--- a/aws/files/autoeips.py
+++ b/aws/files/autoeips.py
@@ -1,3 +1,4 @@
+from botocore.vendored.requests.packages.urllib3.util.retry import Retry
 {% from "aws/map.jinja" import aws with context %}
 #!/usr/bin/env python
 
@@ -5,9 +6,8 @@ import boto.ec2
 import boto.utils
 import logging
 
-
 # Set up the logging
-logging.basicConfig(level=logging.INFO)
+logging.basicConfig(level=logging.{{aws.log_level}})
 logger = logging.getLogger("aws:autoeips")
 logging.getLogger("requests").setLevel(logging.WARNING)
 
@@ -21,23 +21,29 @@ class AutoEIP(object):
         self.instance_metadata = self.get_instance_metadata()
         self.instance_id = self.instance_metadata.get('instance-id')
         # Collect details about this instance
-        vpc_id = self.instance_metadata['network']['interfaces']['macs'].values()[0]['vpc-id']
-        region = self.instance_metadata['placement']['availability-zone'][:-1]
+        vpc_id = (self.instance_metadata['network']
+                  ['interfaces']
+                  ['macs'].values()[0]
+                  ['vpc-id'])
+        region = (self.instance_metadata['placement']
+                  ['availability-zone'][:-1]
+                  )
 
         try:
             self.ec2_connection = boto.ec2.connect_to_region(region)
         except Exception as e:
             # This prints a user-friendly error with stacktrace
-            print("Error getting EC2 conection: {}".format(e))
+            logger.critical("Error getting EC2 conection: {}".format(e))
 
     def update_association(self, force=False):
         instance_associations = self.get_instance_association()
         if len(instance_associations) < 1 or force:
-            print("Associating with any available eips")
+            logger.info("Associating with any available eips in list {}"
+                        .format(self.filter_addresses))
             filtered_eips = self.get_unassociated_eips()
             self.associate_eip(filtered_eips)
         else:
-            print("Already associated with EIP: {}".format(
+            logger.debug("Already associated with EIP: {}".format(
                 instance_associations[0]))
 
     def get_instance_association(self):
@@ -52,27 +58,34 @@ class AutoEIP(object):
         try:
             return boto.utils.get_instance_metadata(timeout=5, num_retries=2)
         except Exception as e:
-            sys.stderr.write("Error getting VPC ips: {}".format(e))
-            return {}
+            logger.critical("Error getting VPC ips: {}".format(e))
+            self.safe_exit(exit_code=1)
 
     def associate_eip(self, eips, retries=3):
         if not self.instance_id:
-            print "Error getting instance_id"
+            logger.critical("Error getting instance_id")
             return False
         for retry in range(retries):
-            print "retry: {}".format(retry)
             for eip in eips:
-                print "Associating instance: {} with eip: {}".format(
-                    self.instance_id, eip.allocation_id)
+                logger.info("Associating instance: {} with eip: {} Retry {}/{}"
+                            .format(self.instance_id,
+                                    eip.allocation_id,
+                                    retry,
+                                    retries)
+                            )
 
                 success = eip.associate(
                     instance_id=self.instance_id, allow_reassociation=False)
-                if success:
-                    return True
-
+                return success
         return False
 
     def get_unassociated_eips(self):
+        # Disallow unrestricted association attempts,
+        # filter addresses must be provided to prevent
+        # over-greedy attempts on capturing EIP's
+        if (self.filter_addresses < 1):
+            logger.critical("No eip addresses specified, aborting...")
+            self.safe_exit(1)
         try:
             eips = self.ec2_connection.get_all_addresses(
                 addresses=self.filter_addresses)
@@ -80,17 +93,21 @@ class AutoEIP(object):
             unassociated_eips = \
                 [eip for eip in eips if eip.association_id is None]
 
-            print("Found {} eips: {}".format(len(eips), eips))
-            print("Found {} unassociated eips: {}".format(
-                len(unassociated_eips), unassociated_eips))
+            logger.info("Found {} eips: {}".format(len(eips), eips))
+            logger.info("Found {} unassociated eips: {}"
+                        .format(len(unassociated_eips),
+                                unassociated_eips)
+                        )
 
             return unassociated_eips
 
         except Exception as e:
             # This prints a user-friendly error with stacktrace
-            logger.exception("Error getting EIPS: {}".format(e))
-            return None
+            logger.critical("Error getting EIPS: {}".format(e))
+            self.safe_exit(exit_code=1)
 
+    def safe_exit(self, exit_code):
+        sys.exit(exit_code)
 
 if __name__ == '__main__':
     autoeip = AutoEIP()

--- a/aws/map.jinja
+++ b/aws/map.jinja
@@ -1,0 +1,6 @@
+{% set aws = salt['grains.filter_by']({
+    'Default': {
+    	'eips': []
+    }
+}, grain='osfinger', merge=salt['pillar.get']('aws',{}), default='Default') %}
+

--- a/aws/map.jinja
+++ b/aws/map.jinja
@@ -1,7 +1,7 @@
 {% set aws = salt['grains.filter_by']({
     'Default': {
     	'eips': [],
-    	'auto_eip_log' = '/var/log/autoeips.log',
+    	'auto_eip_log': '/var/log/autoeips.log',
     	'log_level': 'INFO'
     }
 }, grain='osfinger', merge=salt['pillar.get']('aws',{}), default='Default') %}

--- a/aws/map.jinja
+++ b/aws/map.jinja
@@ -1,6 +1,7 @@
 {% set aws = salt['grains.filter_by']({
     'Default': {
-    	'eips': []
+    	'eips': [],
+    	'log_level': 'INFO'
     }
 }, grain='osfinger', merge=salt['pillar.get']('aws',{}), default='Default') %}
 

--- a/aws/map.jinja
+++ b/aws/map.jinja
@@ -1,6 +1,7 @@
 {% set aws = salt['grains.filter_by']({
     'Default': {
     	'eips': [],
+    	'auto_eip_log' = '/var/log/autoeips.log',
     	'log_level': 'INFO'
     }
 }, grain='osfinger', merge=salt['pillar.get']('aws',{}), default='Default') %}


### PR DESCRIPTION
The change adds a script that can associate an EIP with an instance
based on pillar data listing ips that should be targeted. This is
part of the Covet IP pattern for maintaining EIP's on instances.
