### PR TITLE
Fix early exit on EIP association

### DIFF
--- a/aws/files/autoeips.py
+++ b/aws/files/autoeips.py
@@ -121,8 +121,10 @@ class AutoEIP(object):
 
                 success = eip.associate(
                     instance_id=self.instance_id, allow_reassociation=False)
-                self.update_standby_mode(False)
-                return success
+                # If the association was successful, update the standby mode and exit
+                if success:
+                    self.update_standby_mode(False)
+                    return success
         logger.warning("Failed to associate with any EIP's")
         self.update_standby_mode(True)
         return False


### PR DESCRIPTION
The code doesnt handle failure to acquire an EIP and retry logic
properly, this change means that it will properly retry to acquire
EIP's on failure rather than just exiting.
