### PR TITLE
Cleanup crontab

### DIFF
--- a/aws/autoeips.sls
+++ b/aws/autoeips.sls
@@ -18,6 +18,12 @@ boto3:
   pip.installed:
     - user: root
 
+cron_cleanup:
+  cmd.run:
+    - name: crontab -l | grep -v 'autoeips.py'  | crontab -
+    - require_in:
+      - state: cron_autoeips
+
 cron_autoeips:
   cron.present:
     - name: python /usr/local/bin/autoeips.py >> {{ aws.auto_eip_log }} 2>&1


### PR DESCRIPTION
This change makes sure we don't get duplicate cron entries when we
makes autoeips changes by removing old entries from the crontab
before adding the new.
