### PR TITLE
Add error level number to logging

### DIFF
--- a/aws/files/autoeips.py
+++ b/aws/files/autoeips.py
@@ -276,7 +276,7 @@ class AutoEIP(object):
         Setup the logging
         """
         if log_format == 'json':
-            logging_format_str = '{"timestamp": "%(asctime)s","name": "%(name)s", "level": "%(levelname)s", "message": "%(message)s"}'
+            logging_format_str = '{"timestamp": "%(asctime)s","name": "%(name)s", "level": "%(levelname)s", level_no: "%(levelno)s", "message": "%(message)s"}'
         else:
             logging_format_str = '%(asctime)s %(name)s: %(levelname)s: %(message)s'
 


### PR DESCRIPTION
This add the logging error integer equivalent information to the
json messages to allow for integer comparisons of error severity.
