### PR TITLE
Add failover mode

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -107,6 +107,11 @@ a more resilient and automated solution than assigning EIP's manually.
     # instances automatically dependent on whether thay have 
     # acquired an EIP or not
     eip_enable_standby_mode: True
+    # Enable or disable the use of failover mode to add and remove
+    # instances automatically dependent on whether thay have
+    # acquired an EIP or not. This is the same as stnadby mode but
+    # does not alert.
+    eip_enable_failover_mode: False
 
 
 Note if the standby mode function is enabled, this requires an additional set of IAM permissions.

--- a/aws/autoeips.sls
+++ b/aws/autoeips.sls
@@ -33,5 +33,6 @@ cron_autoeips:
          --log-format {{ aws.log_format }}
          --log-file {{ aws.log_file }}
          {% if aws.eip_enable_standby_mode %}--enable-standby-mode{% endif %}
+         {% if aws.eip_enable_failover_mode %}--enable-failover-mode{% endif %}
     - user: root
     - minute: "*/1"

--- a/aws/map.jinja
+++ b/aws/map.jinja
@@ -4,7 +4,8 @@
     	'log_file': '/var/log/autoeips.log',
     	'log_level': 'INFO',
     	'log_format': 'json',
-    	'eip_enable_standby_mode': True
+    	'eip_enable_standby_mode': True,
+    	'eip_enable_failover_mode': False
     }
 }, grain='osfinger', merge=salt['pillar.get']('aws',{}), default='Default') %}
 


### PR DESCRIPTION
Standby mode means that in the case where there are N elastic ips
available, the Nth+1 instance will put itself into standby mode,
periodically checking for an available EIP and issuing a critical
alert until it finds one. However, there are cases where the extra
instance is acting as a failover, so that when one of the instances
with an EIP fails, it will come out of standby and automatically
take over from the failed instance. When this is the goal, we dont
want the standby instance to issue critical alerts as it is the
desired behaviour. This change simply add the --enable-failover-mode
option to the autoeips script to enable this behaviour.