### PR TITLE
Add AWSlogs agent state

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -129,3 +129,42 @@ The autoscaling permissions are required if the standby functionality is enabled
 	"autoscaling:EnterStandby",
 	"autoscaling:ExitStandby"
 
+AWSLog Agent
+############
+
+The aws.awslogs state sets up the awslogs agent on the instance. It configures
+a number of common log paths by default. See http://docs.aws.amazon.com/AmazonCloudWatch/latest/logs/QuickStartEC2Instance.html
+
+Note, the instance role must have permissions to work with CloudWatch, 
+
+.. code:: json
+
+  {
+      "Effect": "Allow",
+      "Action": [
+        "logs:CreateLogGroup",
+        "logs:CreateLogStream",
+        "logs:PutLogEvents",
+        "logs:DescribeLogStreams"
+    ],
+      "Resource": [
+        "arn:aws:logs:*:*:*"
+    ]
+  }
+
+The following covers some of the pillar options available, in general the defaults
+should be enough in most cases.
+
+.. code::
+
+  aws:
+    awslogs:
+      # A dictionary of log group name to log path entries
+      # There are a number of common paths provided by default
+      log_files:
+        <log_group_name>: <log_file_path> 
+        <log_group_name>: <log_file_path> 
+      # The log group prefix override, this defaults to the stack name.
+      log_group_prefix: my-stack-name
+      # The grain to use as the stream id, defaults to instance id
+      log_stream_id_grain: aws_instance_id

--- a/aws/awslogs.sls
+++ b/aws/awslogs.sls
@@ -1,0 +1,28 @@
+{% from "aws/map.jinja" import aws with context %}
+
+awslogs-agent-setup:
+  cmd.run:
+    - name: curl -L https://s3.amazonaws.com/aws-cloudwatch/downloads/latest/awslogs-agent-setup.py -o /tmp/awslogs-agent-setup.py
+    - creates: /tmp/awslogs-agent-setup.py
+
+awslogs-agent-setup-run:
+  cmd.run:
+    - name: python /tmp/awslogs-agent-setup.py -n -r eu-west-1 -c /tmp/awslogs.conf
+    - onchanges:
+      - file: awslogs.conf
+    - require:
+      - cmd: awslogs-agent-setup
+      - file: awslogs.conf
+
+
+awslogs.conf:
+  file.managed:
+    - name: /tmp/awslogs.conf
+    - source: salt://aws/files/awslogs.conf
+    - template: jinja
+
+awslogs:
+  service.running:
+    - enable: True
+    - onchanges:
+      - cmd: awslogs-agent-setup-run

--- a/aws/files/awslogs.conf
+++ b/aws/files/awslogs.conf
@@ -1,0 +1,13 @@
+{% from "aws/map.jinja" import aws with context %}
+
+[general]
+state_file = /var/awslogs/state/agent-state
+{% for log_group, log_file in aws.awslogs.log_files.items() %}
+[{{ log_group }}]
+datetime_format = %Y-%m-%d %H:%M:%S
+file = {{ log_file }}
+buffer_duration = 5000
+log_stream_name = {{ grains[aws.awslogs.log_stream_id_grain] }}
+initial_position = start_of_file
+log_group_name = {{ aws.awslogs.log_group_prefix }}{{ log_group }}
+{% endfor %}

--- a/aws/map.jinja
+++ b/aws/map.jinja
@@ -1,11 +1,24 @@
 {% set aws = salt['grains.filter_by']({
     'Default': {
-    	'eips': [],
-    	'log_file': '/var/log/autoeips.log',
-    	'log_level': 'INFO',
-    	'log_format': 'json',
-    	'eip_enable_standby_mode': True,
-    	'eip_enable_failover_mode': False
+      'eips': [],
+      'log_file': '/var/log/autoeips.log',
+      'log_level': 'INFO',
+      'log_format': 'json',
+      'eip_enable_standby_mode': True,
+      'eip_enable_failover_mode': False,
+      'awslogs': {
+        'log_files': {
+          '/var/log/syslog': '/var/log/syslog',
+          '/var/log/kern.log': '/var/log/kern.log',
+          '/var/log/nginx': '/var/log/nginx/*.json',
+          '/var/log/upstart': '/var/log/upstart/*.log',
+          '/var/lib/docker/containers': '/var/lib/docker/containers/*/*.log',
+          '/var/log/cron.log': '/var/log/cron.log',
+          '/var/log/stunnel_scanner.log': '/var/log/stunnel_scanner.log'
+        },
+        'log_group_prefix': salt['grains.get']('aws:cloudformation:stack-name', delimiter='|'),
+        'log_stream_id_grain': 'aws_instance_id'
+      }
     }
 }, grain='osfinger', merge=salt['pillar.get']('aws',{}), default='Default') %}
 


### PR DESCRIPTION
This change creates a state called aws.awslogs that will ensure that
the awslogs agent is running with the default supplied configuration.